### PR TITLE
Include domain when tagging a mastodon user

### DIFF
--- a/toot.py
+++ b/toot.py
@@ -21,7 +21,7 @@ for toot in mdon.notifications():
     if toot["type"] == "mention" and toot["status"]["id"] not in done:
         function = get_function(toot["status"]["content"])
         done.append(toot["status"]["id"])
-        user = toot["account"]["username"]
+        user = toot["account"]["acct"]
         if function is not None:
             try:
                 f = fp.parse(function)


### PR DESCRIPTION
**Entirely untested, just eyeballing it from the API docs**.

I figure the vast majority of users are going to be on mathstodon.xyz anyways, but this should ensure that users on other instances get proper reply notifications too.